### PR TITLE
Expand symlinks to file-truename of temp-name

### DIFF
--- a/flymake.el
+++ b/flymake.el
@@ -1760,7 +1760,7 @@ copy."
                  (file-name-nondirectory (file-name-sans-extension file-name))
                  "_" prefix))
          (ext  (concat "." (file-name-extension file-name)))
-         (temp-name (make-temp-file name nil ext)))
+         (temp-name (file-truename (make-temp-file name nil ext))))
     (flymake-log 3 "create-temp-intemp: file=%s temp=%s" file-name temp-name)
       temp-name))
 


### PR DESCRIPTION
If temp-name was going through symlinks flymake wouldn't discover the
reported errors.

I.e. on Mac OS X `temporary-file-directory' would be something like
"/var/folders/mc/0b33w8gd1z16sjpmn2xy6fpr0000gn/T/" but /var is a
symlink to /private/var.
