### PR TITLE
Update the regexp for newer GCC to use the correct file-idx.

### DIFF
--- a/flymake.el
+++ b/flymake.el
@@ -1051,7 +1051,7 @@ Convert it to flymake internal format."
      ;; LaTeX warnings (fileless) ("\\(LaTeX \\(Warning\\|Error\\): .*\\) on input line \\([0-9]+\\)" 20 3 nil 1)
      ;; gcc after 4.5 (includes column number)
      (" *\\(\\([a-zA-Z]:\\)?[^:(\t\n]+\\)\:\\([0-9]+\\)\:\\([0-9]+\\)\:[ \t\n]*\\(.+\\)"
-      2 3 4 5)
+      1 3 4 5)
      ;; ant/javac, also matches gcc prior to 4.5
      (" *\\(\\[javac\\] *\\)?\\(\\([a-zA-Z]:\\)?[^:(\t\n]+\\)\:\\([0-9]+\\)\:[ \t\n]*\\(.+\\)"
       2 4 nil 5))


### PR DESCRIPTION
Hi!

I discovered a bug in the flymake-err-line-patterns. The file-idx should use the first matching group (1) and not the second since this group will only (in some cases) contain a drive letter.

For example:
the string "c:/test.cpp:6:4: error: expected ';' before 'return'"
will have the matching groups
1.  c:/test.cpp
2.  c:
3.  6
4.  4
5.  error: expected ';' before 'return'

so it can be seen that the file-idx should be 1 and not 2.

Cheers and thanks for a nice fork!

// Albert
