### PR TITLE
Wrapped temp-name in `file-truename'

### DIFF
--- a/flymake.el
+++ b/flymake.el
@@ -1761,10 +1761,10 @@ copy."
     (error "Invalid file-name"))
   (or prefix
       (setq prefix "flymake"))
-  (let* ((temp-name   (concat (file-name-sans-extension file-name)
-                              "_" prefix
-                              (and (file-name-extension file-name)
-                                   (concat "." (file-name-extension file-name))))))
+  (let* ((temp-name (file-truename (concat (file-name-sans-extension file-name)
+                                           "_" prefix
+                                           (and (file-name-extension file-name)
+                                                (concat "." (file-name-extension file-name)))))))
     (flymake-log 3 "create-temp-inplace: file=%s temp=%s" file-name temp-name)
     temp-name))
 


### PR DESCRIPTION
If the temp-name in `flymake-create-temp-inplace' is going through
symlinks reported errors might not get catched if they contain the
expanded file name.

Wrapping temp-name in `file-truename' will make the file names
consistent in the error reports and in flymake.

This actually identical to the fix 61aa5c98554bc44b3c5d94f18414ddf769993522 in `flymake-create-temp-intemp'.
