### PR TITLE
Fixes problem with flymake-xml-init.

### DIFF
--- a/flymake.el
+++ b/flymake.el
@@ -2163,7 +2163,7 @@ wish to have supplied to Perl -I."
 
 ;;;; xml-specific init-cleanup routines
 (defun flymake-xml-init ()
-  (list "xmlstarlet" (list "val" (flymake-init-create-temp-buffer-copy 'flymake-create-temp-copy))))
+  (list "xmlstarlet" (list "val" "-e" (flymake-init-create-temp-buffer-copy 'flymake-create-temp-inplace))))
 
 (provide 'flymake)
 


### PR DESCRIPTION
Current version throws exception on xmlstarlet 1.3.0 and emacs 24.2.1
(xmlstarlet --version
1.3.0
compiled against libxml2 2.7.8, linked with 20708
compiled against libxslt 1.1.26, linked with 10126)

"Configuration error has occured while running (xmlstarlet val /file_flymake.html). Flymake will be switched OFF"

This patch fixes this and now Flymake works properly with html files in nxml mode.
