### PR TITLE
Fix for non-writable directories

### DIFF
--- a/flymake.el
+++ b/flymake.el
@@ -124,8 +124,13 @@ if ARG is omitted or nil."
                      (not flymake-timer))
             (setq flymake-timer (run-at-time nil 1 'flymake-on-timer-event)))
 
-          (when flymake-start-syntax-check-on-find-file
-            (flymake-start-syntax-check)))))
+	  (when (and flymake-start-syntax-check-on-find-file
+		     ;; Since we write temp files in current dir, there's no point
+		     ;; trying if the directory is read-only (bug#8954).
+		     (or (not flymake-run-in-place)
+                         (file-writable-p (file-name-directory buffer-file-name))))
+	    (with-demoted-errors
+	      (flymake-start-syntax-check))))))
 
     ;; Turning the mode OFF.
     (t


### PR DESCRIPTION
This is the upstream patch for bug #8954, suitably modified to deal with flymake-run-in-place. It should fix issue #12.
