### PR TITLE
Avoid useless output files in gettext mode

### DIFF
--- a/flymake.el
+++ b/flymake.el
@@ -2145,7 +2145,7 @@ wish to have supplied to Perl -I."
            (local-file (file-relative-name
                         temp-file
                         (file-name-directory buffer-file-name))))
-      (list "msgfmt" (list "-c" local-file))))
+      (list "msgfmt" (list "-c" "-o" "/dev/null" local-file))))
 
 
 ;;;; tex-specific init-cleanup routines


### PR DESCRIPTION
The previous coding for the po-mode check left a `messages.po` file lying around wherever it was run.  Add the appropriate options to `msgfmt` to avoid that.
