### PR TITLE
Remove buggy tramp workaround code from flymake-start-syntax-check-process

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+* flymake.el 0.4.17 (2014-08-04-22:39)
+  * Remove problematic TRAMP workaround introduced in 0.4.4.
+    (Patch from @rrthomas)
+
 * flymake.el 0.4.16 (2013-05-19-01:30)
   * Pull upstream patch for non-writable dirs.
     (Prodding provided by @rrthomas, patch originally by Stefan Monnier.)

--- a/README.mkdn
+++ b/README.mkdn
@@ -106,17 +106,11 @@ complicated: the syntax check will be run in the same directory
 as the original file, this (usually) means that it will run in a
 shell on the remote machine.
 
-Flymake attempts to cope with this gracefully, but there's a couple
-of odd behaviours in Tramp which make this difficult:
-
-  * Tramp places the contents of the remote shell login message
-    at the end of the buffer being syntax-checked.
-    This version of Flymake takes steps to prevent this from
-    modifying the buffer in any way.
-  * If the syntax-check command to run is not found on the remote
-    machine, the command process just hangs and never completes.
-    At the moment Flymake has no special handling of this situation
-    and it will mean that the syntax check never appears to finish.
+Flymake attempts to cope with this gracefully, but if the syntax-check
+command to run is not found on the remote machine, the command process just
+hangs and never completes. At the moment Flymake has no special handling of
+this situation and it will mean that the syntax check appears never to
+finish.
 
 Improved error message classification
 -------------------------------------

--- a/flymake.el
+++ b/flymake.el
@@ -4,7 +4,7 @@
 
 ;; Author:  Pavel Kobyakov <pk_at_work@yahoo.com>
 ;; Maintainer: Sam Graham <libflymake-emacs BLAHBLAH illusori.co.uk>
-;; Version: 0.4.16
+;; Version: 0.4.17
 ;; Keywords: c languages tools
 
 ;; This file is part of GNU Emacs.


### PR DESCRIPTION
I just spent a couple of hours tracking down a bug where whenever I opened a Javascript file, Emacs added an extra blank line at the bottom.

This turned out to be down to a combination of the TRAMP workaround code inserting a newline and the fact that I didn't have jslint (or jshint, or whatever) installed, so the checking process errored out, leaving the extra newline in my buffer.

I understand the motivation, but I suggest if there's a bug in TRAMP (and maybe in any case it's fixed now?) it should be fixed in TRAMP. Since flymake.el is in Emacs, bug-emacs@gnu.org would love to know if there are bugs like this that need fixing.

This pull request removes the workaround, and includes the corresponding documentation changes, and version bump and Changes entry.
